### PR TITLE
Fixed GUI bugs

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -533,7 +533,7 @@ bool AppInit2(boost::thread_group& threadGroup)
 
     if (GetBoolArg("-shrinkdebugfile", !fDebug))
         ShrinkDebugFile();
-    LogPrintf("\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n");
+    LogPrintf("\n\n\n"); //A bit excessive???
     LogPrintf("DarkSilk version %s (%s)\n", FormatFullVersion(), CLIENT_DATE);
     LogPrintf("Using OpenSSL version %s\n", SSLeay_version(SSLEAY_VERSION));
     if (!fLogTimestamps)

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -372,7 +372,6 @@ void BitcoinGUI::createActions()
     connect(blockAction, SIGNAL(triggered()), this, SLOT(gotoBlockBrowser()));
     connect(statisticsAction, SIGNAL(triggered()), this, SLOT(showNormalIfMinimized()));
     connect(statisticsAction, SIGNAL(triggered()), this, SLOT(gotoStatisticsPage()));
-    connect(statisticsAction, SIGNAL(triggered()), this, SLOT(updateStatistics()));
     connect(stormnodeManagerAction, SIGNAL(triggered()), this, SLOT(showNormalIfMinimized()));
     connect(stormnodeManagerAction, SIGNAL(triggered()), this, SLOT(gotoStormnodeManagerPage()));
 
@@ -496,13 +495,11 @@ void BitcoinGUI::createToolBars()
     QAction* menuAction = new QAction(QIcon(":/icons/overview"), tr("&Menu"), this);
     menuAction->setToolTip(tr("Access DarkSilk Wallet Tabs"));
     menuAction->setCheckable(false);
-    connect(menuAction, SIGNAL(triggered()), this, SLOT(menuToolButton->showMenu()));
     menuToolButton->setDefaultAction(menuAction);
     
     toolbar->addWidget(menuToolButton);
 
-    netLabel = new QLabel();
-    
+    netLabel = new QLabel();    
 
     toolbar->addWidget(makeToolBarSpacer());
     netLabel->setObjectName("netLabel");
@@ -1024,6 +1021,8 @@ void BitcoinGUI::gotoStatisticsPage()
     statisticsPage = new StatisticsPage(this);
     centralStackedWidget->addWidget(statisticsPage);
     centralStackedWidget->setCurrentWidget(statisticsPage);
+
+    statisticsPage->updateStatistics();
 
     exportAction->setEnabled(false);
     disconnect(exportAction, SIGNAL(triggered()), 0, 0);


### PR DESCRIPTION
Issue:  GUI: QObject::connect: No such slot
BitcoinGUI::updateStatistics()
Fix: Since the updateStatistics slot does not exist, I removed the event
and added a call to update statistics when the overview page is loaded.

Issue: GUI: QObject::connect: No such slot BitcoinGUI::menuToolButton-
Fix: Removed unnecessary event since showMenu() is inherited by the
QToolButton when setting default action.